### PR TITLE
optimizing queries

### DIFF
--- a/models/admin.go
+++ b/models/admin.go
@@ -24,7 +24,7 @@ type Record struct {
 
 // GetAdminInformation returns dashboard information
 func GetAdminInformation() *AdminInformation {
-	row := pigo.Database.QueryRow("SELECT (SELECT COUNT(*) FROM accounts) as accounts, (SELECT COUNT(*) FROM players) players, (SELECT COUNT(*) FROM players WHERE vocation IN(1, 5)) as sorcerers, (SELECT COUNT(*) FROM players WHERE vocation IN (2, 6)) as druids, (sELECT COUNT(*) FROM players WHERE vocation IN (3, 7)) as paladins, (SELECT COUNT(*) FROM players WHERE vocation IN (4, 8)) as knights, (SELECT COUNT(*) FROM players WHERE sex = 1) as males, (SELECT COUNT(*) FROM players WHERE sex = 0) as females")
+	row := pigo.Database.QueryRow("SELECT (SELECT COUNT(1) FROM accounts) as accounts, (SELECT COUNT(1) FROM players) players, (SELECT COUNT(1) FROM players WHERE vocation IN(1, 5)) as sorcerers, (SELECT COUNT(1) FROM players WHERE vocation IN (2, 6)) as druids, (SELECT COUNT(1) FROM players WHERE vocation IN (3, 7)) as paladins, (SELECT COUNT(1) FROM players WHERE vocation IN (4, 8)) as knights, (SELECT COUNT(1) FROM players WHERE sex = 1) as males, (SELECT COUNT(1) FROM players WHERE sex = 0) as females")
 	info := &AdminInformation{}
 	row.Scan(&info.Accounts, &info.Players, &info.Sorcerers, &info.Druids, &info.Paladins, &info.Knights, &info.Males, &info.Females)
 	return info
@@ -38,7 +38,7 @@ func ClearOnlineLogs() error {
 
 // GetOnlineCount returns the current online number of players
 func GetOnlineCount() int {
-	row := pigo.Database.QueryRow("SELECT COUNT(*) FROM players_online")
+	row := pigo.Database.QueryRow("SELECT COUNT(1) FROM players_online")
 	total := 0
 	row.Scan(&total)
 	return total

--- a/models/guilds.go
+++ b/models/guilds.go
@@ -45,7 +45,7 @@ func NewGuild() *Guild {
 // GetGuildList gets the full list from database
 func GetGuildList() ([]*Guild, error) {
 	list := []*Guild{}
-	rows, err := pigo.Database.Query("SELECT a.name, a.creationdata, a.motd, b.name, (SELECT COUNT(*) FROM guild_membership WHERE a.id = guild_id) AS members, (SELECT COUNT(*) FROM guild_membership c, players_online d WHERE c.player_id = d.player_id AND c.guild_id = a.id) AS onl, (SELECT MAX(f.level) FROM guild_membership e, players f WHERE f.id = e.player_id AND e.guild_id = a.id) as top, (SELECT MIN(f.level) FROM guild_membership e, players f WHERE f.id = e.player_id AND e.guild_id = a.id) as low FROM guilds a, players b WHERE a.ownerid = b.id ORDER BY a.creationdata DESC")
+	rows, err := pigo.Database.Query("SELECT a.name, a.creationdata, a.motd, b.name, (SELECT COUNT(1) FROM guild_membership WHERE a.id = guild_id) AS members, (SELECT COUNT(1) FROM guild_membership c, players_online d WHERE c.player_id = d.player_id AND c.guild_id = a.id) AS onl, (SELECT MAX(f.level) FROM guild_membership e, players f WHERE f.id = e.player_id AND e.guild_id = a.id) as top, (SELECT MIN(f.level) FROM guild_membership e, players f WHERE f.id = e.player_id AND e.guild_id = a.id) as low FROM guilds a, players b WHERE a.ownerid = b.id ORDER BY a.creationdata DESC")
 	defer rows.Close()
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func (guild *Guild) Create() error {
 
 // GetGuildByName gets a guild by its name
 func GetGuildByName(name string) (*Guild, error) {
-	row := pigo.Database.QueryRow("SELECT a.ownerid, a.id, a.name, a.creationdata, a.motd, b.name, (SELECT COUNT(*) FROM guild_membership WHERE a.id = guild_id) AS members, (SELECT COUNT(*) FROM guild_membership c, players_online d WHERE c.player_id = d.player_id AND c.guild_id = a.id) AS onl, (SELECT MAX(f.level) FROM guild_membership e, players f WHERE f.id = e.player_id AND e.guild_id = a.id) as top, (SELECT MIN(f.level) FROM guild_membership e, players f WHERE f.id = e.player_id AND e.guild_id = a.id) as low FROM guilds a, players b WHERE a.ownerid = b.id AND a.name = ?", name)
+	row := pigo.Database.QueryRow("SELECT a.ownerid, a.id, a.name, a.creationdata, a.motd, b.name, (SELECT COUNT(1) FROM guild_membership WHERE a.id = guild_id) AS members, (SELECT COUNT(1) FROM guild_membership c, players_online d WHERE c.player_id = d.player_id AND c.guild_id = a.id) AS onl, (SELECT MAX(f.level) FROM guild_membership e, players f WHERE f.id = e.player_id AND e.guild_id = a.id) as top, (SELECT MIN(f.level) FROM guild_membership e, players f WHERE f.id = e.player_id AND e.guild_id = a.id) as low FROM guilds a, players b WHERE a.ownerid = b.id AND a.name = ?", name)
 	guild := NewGuild()
 	row.Scan(&guild.Owner.ID, &guild.ID, &guild.Name, &guild.Creation, &guild.Motd, &guild.Owner.Name, &guild.Info.Members, &guild.Info.Online, &guild.Info.Top, &guild.Info.Low)
 	rows, err := pigo.Database.Query("SELECT p.id, p.name, p.level, p.vocation, gm.nick, gr.name AS rank_name, IF(po.player_id IS NULL, 0, 1) as onl FROM players AS p LEFT JOIN guild_membership AS gm ON gm.player_id = p.id LEFT JOIN guild_ranks AS gr ON gr.id = gm.rank_id LEFT JOIN players_online AS po ON p.id = po.player_id WHERE gm.guild_id = ? ORDER BY gm.rank_id, p.name", guild.ID)

--- a/models/players.go
+++ b/models/players.go
@@ -64,7 +64,7 @@ type HighscorePlayer struct {
 
 // GetTopPlayers gets sidebar top players
 func GetTopPlayers(limit int) ([]*Player, error) {
-	rows, err := pigo.Database.Query("SELECT name, level FROM players ORDER BY level DESC LIMIT ?", limit)
+	rows, err := pigo.Database.Query("SELECT name, level FROM players ORDER BY experience DESC LIMIT ?", limit)
 	if err != nil {
 		return nil, err
 	}

--- a/util/highscores.go
+++ b/util/highscores.go
@@ -12,7 +12,7 @@ func GetHighscoreQuery(page int, highscoreType string, per int) (int, string, st
 	switch highscoreType {
 	case "level":
 		skillName = "Experience"
-		query = fmt.Sprintf("SELECT name, level FROM players ORDER BY level DESC LIMIT %v, %v",
+		query = fmt.Sprintf("SELECT name, level FROM players ORDER BY experience DESC LIMIT %v, %v",
 			pageIndex,
 			per,
 		)


### PR DESCRIPTION
- replaced `SELECT COUNT(*)` to `SELECT COUNT(1)`
- fixed top players order by `experience` instead `level`